### PR TITLE
some generalization

### DIFF
--- a/zfs_stats.sh
+++ b/zfs_stats.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/bash
 # Script by Marianne M. Spiller <marianne.spiller@dfki.de>
 # 20180118
 
@@ -10,9 +10,9 @@ STATE_CRITICAL=2
 STATE_UNKNOWN=3
 
 ##---- Ensure we're using GNU tools
-DATE="/usr/gnu/bin/date"
-GREP="/usr/gnu/bin/grep"
-WC="/usr/gnu/bin/wc"
+DATE=$({ which gdate || which date } | tail -1)
+GREP=$({ which ggrep || which grep } | tail -1)
+WC=$({ which gwc || which wc } | tail -1)
 
 read -d '' USAGE <<- _EOF_
 $PROG [ -c <critical_space> ] [ -w <warning_space> ] -d <dataset>
@@ -84,10 +84,10 @@ if [ -z "$CRITICAL_PERCENT" ] ; then
   CRITICAL_PERCENT="5"
 fi
 
-USED=`zfs list -Hp -o used $ZFS_DATASET`
-AVAIL=`zfs list -Hp -o avail $ZFS_DATASET`
+USED=`zfs list -H -o used $ZFS_DATASET`
+AVAIL=`zfs list -H -o avail $ZFS_DATASET`
 AVAIL_READABLE=`zfs list -H -o avail $ZFS_DATASET`
-REFER=`zfs list -Hp -o refer $ZFS_DATASET`
+REFER=`zfs list -H -o refer $ZFS_DATASET`
 QUOTA=`zfs get -Hp -o value quota $ZFS_DATASET`
 
 if [ "$QUOTA" -eq 0 ] ; then

--- a/zfs_stats.sh
+++ b/zfs_stats.sh
@@ -117,9 +117,10 @@ else
   QUOTA_READABLE=`zfs get -H -o value quota $ZFS_DATASET`
 fi
 
-DIFF=$(echo $QUOTA - $USED | bc -l )
-WARNING_VALUE=$(echo $USED*$WARNING_PERCENT/100|bc -l )
-CRITICAL_VALUE=$(echo $USED*$CRITICAL_PERCENT/100|bc -l )
+DIFF=$(echo "($QUOTA - $USED) * 1" | bc )
+DIFF=${DIFF%%.*}
+WARNING_VALUE=$(echo $USED*$WARNING_PERCENT/100|bc )
+CRITICAL_VALUE=$(echo $USED*$CRITICAL_PERCENT/100|bc )
 
 ##----------- Informational output follows
 read -d '' FYI <<- _EOF_

--- a/zfs_stats.sh
+++ b/zfs_stats.sh
@@ -60,6 +60,16 @@ cat <<- _EOF_
 _EOF_
 }
 
+_humantoscriptable() {
+case $1 in
+  *K)  VAR=$(echo $(echo $1 | cut -d 'K') * 1024 | bc -l)
+  *M)  VAR=$(echo $(echo $1 | cut -d 'K') * 1024 * 1024 | bc -l)
+  *G)  VAR=$(echo $(echo $1 | cut -d 'K') * 1024 * 1024 * 1024 | bc -l)
+  *T)  VAR=$(echo $(echo $1 | cut -d 'K') * 1024 * 1024 * 1024 * 1024 | bc -l)
+esac
+return $VAR
+}
+
 _getopts $@
 
 if [ -z "$ZFS_DATASET" ] ; then
@@ -84,11 +94,11 @@ if [ -z "$CRITICAL_PERCENT" ] ; then
   CRITICAL_PERCENT="5"
 fi
 
-USED=`zfs list -H -o used $ZFS_DATASET | sed -e 's/K/000/g' -e 's/M/000000/g' -e 's/G/000000000/g'`
-AVAIL=`zfs list -H -o avail $ZFS_DATASET | sed -e 's/K/000/g' -e 's/M/000000/g' -e 's/G/000000000/g'`
-AVAIL_READABLE=`zfs list -H -o avail $ZFS_DATASET | sed -e 's/K/000/g' -e 's/M/000000/g' -e 's/G/000000000/g'`
-REFER=`zfs list -H -o refer $ZFS_DATASET | sed -e 's/K/000/g' -e 's/M/000000/g' -e 's/G/000000000/g'`
-QUOTA=`zfs get -Hp -o value quota $ZFS_DATASET | sed -e 's/K/000/g' -e 's/M/000000/g' -e 's/G/000000000/g'`
+USED=`zfs list -H -o used $ZFS_DATASET`; USED=_humantoscriptable $USED
+AVAIL=`zfs list -H -o avail $ZFS_DATASET`; AVAIL=_humantoscriptable $AVAIL
+AVAIL_READABLE=`zfs list -H -o avail $ZFS_DATASET`; AVAIL_READABLE=_humantoscriptable $AVAIL_READABLE
+REFER=`zfs list -H -o refer $ZFS_DATASET`; REFER=_humantoscriptable $REFER
+QUOTA=`zfs get -Hp -o value quota $ZFS_DATASET`; QUOTA=_humantoscriptable $QUOTA
 
 if [ "$QUOTA" -eq 0 ] ; then
   echo "WARNING: no quota set for $ZFS_DATASET. You should consider to set limits. Using overall limits now."

--- a/zfs_stats.sh
+++ b/zfs_stats.sh
@@ -118,8 +118,8 @@ else
 fi
 
 DIFF=$(expr $QUOTA-$USED )
-WARNING_VALUE=$(( $USED*$WARNING_PERCENT/100|bc -l ))
-CRITICAL_VALUE=$(( $USED*$CRITICAL_PERCENT/100|bc -l ))
+WARNING_VALUE=$(expr $USED*$WARNING_PERCENT/100|bc -l )
+CRITICAL_VALUE=$(expr $USED*$CRITICAL_PERCENT/100|bc -l )
 
 ##----------- Informational output follows
 read -d '' FYI <<- _EOF_

--- a/zfs_stats.sh
+++ b/zfs_stats.sh
@@ -84,11 +84,11 @@ if [ -z "$CRITICAL_PERCENT" ] ; then
   CRITICAL_PERCENT="5"
 fi
 
-USED=`zfs list -H -o used $ZFS_DATASET | sed -e 's/K/000/g' -e 's/M/000000/g' -s '/G/000000000/g'`
-AVAIL=`zfs list -H -o avail $ZFS_DATASET | sed -e 's/K/000/g' -e 's/M/000000/g' -s '/G/000000000/g'`
-AVAIL_READABLE=`zfs list -H -o avail $ZFS_DATASET | sed -e 's/K/000/g' -e 's/M/000000/g' -s '/G/000000000/g'`
-REFER=`zfs list -H -o refer $ZFS_DATASET | sed -e 's/K/000/g' -e 's/M/000000/g' -s '/G/000000000/g'`
-QUOTA=`zfs get -Hp -o value quota $ZFS_DATASET | sed -e 's/K/000/g' -e 's/M/000000/g' -s '/G/000000000/g'`
+USED=`zfs list -H -o used $ZFS_DATASET | sed -e 's/K/000/g' -e 's/M/000000/g' -e 's/G/000000000/g'`
+AVAIL=`zfs list -H -o avail $ZFS_DATASET | sed -e 's/K/000/g' -e 's/M/000000/g' -e 's/G/000000000/g'`
+AVAIL_READABLE=`zfs list -H -o avail $ZFS_DATASET | sed -e 's/K/000/g' -e 's/M/000000/g' -e 's/G/000000000/g'`
+REFER=`zfs list -H -o refer $ZFS_DATASET | sed -e 's/K/000/g' -e 's/M/000000/g' -e 's/G/000000000/g'`
+QUOTA=`zfs get -Hp -o value quota $ZFS_DATASET | sed -e 's/K/000/g' -e 's/M/000000/g' -e 's/G/000000000/g'`
 
 if [ "$QUOTA" -eq 0 ] ; then
   echo "WARNING: no quota set for $ZFS_DATASET. You should consider to set limits. Using overall limits now."

--- a/zfs_stats.sh
+++ b/zfs_stats.sh
@@ -104,20 +104,20 @@ if [ -z "$CRITICAL_PERCENT" ] ; then
 fi
 
 USED=`zfs list -H -o used $ZFS_DATASET`; USED=$(_humantoscriptable $USED)
-AVAIL=`zfs list -H -o avail $ZFS_DATASET`; AVAIL=$(_humantoscriptable $AVAIL); AVAIL=$(echo $USED + $AVAIL | bc -l)
+AVAIL=`zfs list -H -o avail $ZFS_DATASET`; AVAIL=$(_humantoscriptable $AVAIL);
 AVAIL_READABLE=`zfs list -H -o avail $ZFS_DATASET`; 
 REFER=`zfs list -H -o refer $ZFS_DATASET`; REFER=$(_humantoscriptable $REFER)
 QUOTA=`zfs get -Hp -o value quota $ZFS_DATASET`; QUOTA=$(_humantoscriptable $QUOTA)
 
 if [ $QUOTA -eq 0 ] ; then
   echo "WARNING: no quota set for $ZFS_DATASET. You should consider to set limits. Using overall limits now."
-  QUOTA="$AVAIL"
+  QUOTA=$(echo $USED + $AVAIL | bc -l)
   QUOTA_READABLE="- no quota -"
 else
   QUOTA_READABLE=`zfs get -H -o value quota $ZFS_DATASET`
 fi
 
-DIFF=$(echo "($QUOTA - $USED) * 1" | bc )
+DIFF=$(echo "$QUOTA - $USED" | bc )
 DIFF=${DIFF%%.*}
 WARNING_VALUE=$(echo $USED*$WARNING_PERCENT/100|bc )
 CRITICAL_VALUE=$(echo $USED*$CRITICAL_PERCENT/100|bc )

--- a/zfs_stats.sh
+++ b/zfs_stats.sh
@@ -16,9 +16,9 @@ WC=$({ which gwc || which wc; } | tail -1)
 
 read -d '' USAGE <<- _EOF_
 $PROG [ -c <critical_space> ] [ -w <warning_space> ] -d <dataset>
-  -c : Optional: CRITICAL space left for dataset (default: ???)
+  -c : Optional: CRITICAL space left for dataset (default: 5%)
   -d : dataset to check
-  -w : Optional: WARNING space left for dataset (default: ???)
+  -w : Optional: WARNING space left for dataset (default: 10%)
 _EOF_
 
 _usage() {
@@ -131,12 +131,12 @@ Dataset information about $ZFS_DATASET:
 
 _EOF_
 
-if [ $DIFF -lt $WARNING_VALUE ] ; then
+if [ $DIFF -lt $CRITICAL_VALUE ] ; then
   echo "CRITICAL: only $AVAIL_READABLE available, dataset $ZFS_DATASET nearly full; consider increasing quota or deleting data."
   echo "$FYI"
   _performance_data
   exit $STATE_CRITICAL
-elif [ $DIFF -lt $CRITICAL_VALUE ] ; then
+elif [ $DIFF -lt $WARNING_VALUE ] ; then
   echo "WARNING: only $AVAIL_READABLE available, dataset $ZFS_DATASET is getting full. Please investigate."
   echo "$FYI"
   _performance_data

--- a/zfs_stats.sh
+++ b/zfs_stats.sh
@@ -84,11 +84,11 @@ if [ -z "$CRITICAL_PERCENT" ] ; then
   CRITICAL_PERCENT="5"
 fi
 
-USED=`zfs list -H -o used $ZFS_DATASET`
-AVAIL=`zfs list -H -o avail $ZFS_DATASET`
-AVAIL_READABLE=`zfs list -H -o avail $ZFS_DATASET`
-REFER=`zfs list -H -o refer $ZFS_DATASET`
-QUOTA=`zfs get -Hp -o value quota $ZFS_DATASET`
+USED=`zfs list -H -o used $ZFS_DATASET | sed -e 's/K/000/g' -e 's/M/000000/g' -s '/G/000000000/g'`
+AVAIL=`zfs list -H -o avail $ZFS_DATASET | sed -e 's/K/000/g' -e 's/M/000000/g' -s '/G/000000000/g'`
+AVAIL_READABLE=`zfs list -H -o avail $ZFS_DATASET | sed -e 's/K/000/g' -e 's/M/000000/g' -s '/G/000000000/g'`
+REFER=`zfs list -H -o refer $ZFS_DATASET | sed -e 's/K/000/g' -e 's/M/000000/g' -s '/G/000000000/g'`
+QUOTA=`zfs get -Hp -o value quota $ZFS_DATASET | sed -e 's/K/000/g' -e 's/M/000000/g' -s '/G/000000000/g'`
 
 if [ "$QUOTA" -eq 0 ] ; then
   echo "WARNING: no quota set for $ZFS_DATASET. You should consider to set limits. Using overall limits now."

--- a/zfs_stats.sh
+++ b/zfs_stats.sh
@@ -104,8 +104,8 @@ if [ -z "$CRITICAL_PERCENT" ] ; then
 fi
 
 USED=`zfs list -H -o used $ZFS_DATASET`; USED=$(_humantoscriptable $USED)
-AVAIL=`zfs list -H -o avail $ZFS_DATASET`; AVAIL=$(_humantoscriptable $AVAIL)
-AVAIL_READABLE=`zfs list -H -o avail $ZFS_DATASET`; AVAIL_READABLE=$(_humantoscriptable $AVAIL_READABLE)
+AVAIL=`zfs list -H -o avail $ZFS_DATASET`; AVAIL=$(_humantoscriptable $AVAIL); AVAIL=$(echo $USED + $AVAIL | bc -l)
+AVAIL_READABLE=`zfs list -H -o avail $ZFS_DATASET`; 
 REFER=`zfs list -H -o refer $ZFS_DATASET`; REFER=$(_humantoscriptable $REFER)
 QUOTA=`zfs get -Hp -o value quota $ZFS_DATASET`; QUOTA=$(_humantoscriptable $QUOTA)
 
@@ -117,9 +117,9 @@ else
   QUOTA_READABLE=`zfs get -H -o value quota $ZFS_DATASET`
 fi
 
-DIFF=$(expr $QUOTA-$USED )
-WARNING_VALUE=$(expr $USED*$WARNING_PERCENT/100|bc -l )
-CRITICAL_VALUE=$(expr $USED*$CRITICAL_PERCENT/100|bc -l )
+DIFF=$(echo $QUOTA - $USED | bc -l )
+WARNING_VALUE=$(echo $USED*$WARNING_PERCENT/100|bc -l )
+CRITICAL_VALUE=$(echo $USED*$CRITICAL_PERCENT/100|bc -l )
 
 ##----------- Informational output follows
 read -d '' FYI <<- _EOF_

--- a/zfs_stats.sh
+++ b/zfs_stats.sh
@@ -10,9 +10,9 @@ STATE_CRITICAL=2
 STATE_UNKNOWN=3
 
 ##---- Ensure we're using GNU tools
-DATE=$({ which gdate || which date } | tail -1)
-GREP=$({ which ggrep || which grep } | tail -1)
-WC=$({ which gwc || which wc } | tail -1)
+DATE=$({ which gdate || which date; } | tail -1)
+GREP=$({ which ggrep || which grep; } | tail -1)
+WC=$({ which gwc || which wc; } | tail -1)
 
 read -d '' USAGE <<- _EOF_
 $PROG [ -c <critical_space> ] [ -w <warning_space> ] -d <dataset>


### PR DESCRIPTION
Hi.

We still use some Solaris 11 boxes here and I tried to make the check compatible. As we don't have a newer Solaris (nor plan to have it), **I can't test my changes on Sol12+.**

Some thoughts:
- I think, if there is no QUOTA set, we should set it to the size of the pool, not only the available space
- we first have to check for CRIT, then WARN. Messages are wrong otherwise ...